### PR TITLE
Adds initialization of dataset when axes are not None

### DIFF
--- a/qcore/experiment.py
+++ b/qcore/experiment.py
@@ -229,6 +229,8 @@ class ExperimentManager:
 
             if dset.axes is None:
                 dset.initialize(axes=list(sweep_dict.values()))
+            else:
+                dset.initialize(axes=dset.axes)
 
 
 class Experiment:


### PR DESCRIPTION
This PR aims to fix the issue reported [here](https://www.notion.so/qcrew/Adding-axes-to-dataset-causes-plotting-to-crash-a09d68048c8941859acae26f3fb7d69a?pvs=4). The issue was caused by the dataset not being initialized when the axes is set to something other than `None`. This is fixed by simple adding in a clause to handle that scenario.